### PR TITLE
Many2one mods

### DIFF
--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -104,7 +104,9 @@ struct SprayData
   amrex::GpuArray<int, NUM_SPECIES - 1> pc_manifold_indx{};
 #endif
   int N_pc = 0;
-  int* pc_indx = nullptr;
+  // We will only use the furst N_pc entries, but don't know that number a
+  // priori so allocate NUM_SPECIES which is always >= N_pc
+  amrex::GpuArray<int, NUM_SPECIES> pc_indx;
 
   // Instance of the liquid properties for the specified model
   pele::physics::SprayProps::LiqPropType liqprops;

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -84,7 +84,6 @@ struct SprayData
   bool mom_trans = true;    // If momentum transfer is on
   bool fixed_parts = false; // If particles are fixed in place
   bool do_splash = false;
-  bool liquid_spec_share_gas_dep = false;
   int do_breakup = 0; // 0 - no breakup modeling, 1 - TAB model, 2 - KHRT model
   // Min cell volume fraction to add sources to
   amrex::Real min_eb_vfrac = 0.05;

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -104,7 +104,7 @@ struct SprayData
   amrex::GpuArray<int, NUM_SPECIES - 1> pc_manifold_indx{};
 #endif
   int N_pc = 0;
-  // We will only use the furst N_pc entries, but don't know that number a
+  // We will only use the first N_pc entries, but don't know that number a
   // priori so allocate NUM_SPECIES which is always >= N_pc
   amrex::GpuArray<int, NUM_SPECIES> pc_indx;
 

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -79,6 +79,7 @@ struct GasPhaseVals
 // Structure containing values for the liquid sprays
 struct SprayData
 {
+  int verbose = 0;          // Same as m_verbose in the SprayParticleContainer
   bool mass_trans = true;   // If evaporation is on
   bool mom_trans = true;    // If momentum transfer is on
   bool fixed_parts = false; // If particles are fixed in place

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -65,46 +65,48 @@ struct BaseLiqProps
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> latentRef_minus_gasRefH_i;
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
-  init_mw(const RealArrayLike& mw_gas, const int* dep_indx)
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void init_mw(
+    const RealArrayLike& mw_gas,
+    const int* dep_indx,
+    const int N_pc = SPRAY_FUEL_NUM)
   {
-#if SPRAY_FUEL_NUM <= NUM_SPECIES
-    // Use gas-phase molecular weights for the liquid species
-    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      const int fdspec = dep_indx[spf];
-      mw[spf] = mw_gas[fdspec] * SprayUnits::mass_conv;
-    }
-#ifdef PELE_SPRAY_GCM
-    {
-      amrex::ParmParse pp("particles");
-      std::vector<std::string> fuel_names;
-      pp.getarr("fuel_species", fuel_names);
-      amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> mw_fl;
-      getInpVal(mw_fl.data(), pp, fuel_names.data(), "molar_weight");
+    if (N_pc == SPRAY_FUEL_NUM) {
+      // Use gas-phase molecular weights for the liquid species
       for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-        const amrex::Real diff = std::abs(mw_fl[spf] - mw[spf]);
-        if (diff > 1.E-3) {
-          amrex::Warning(
-            "Warning: GCM species " + fuel_names[spf] + " mw " +
-            std::to_string(mw_fl[spf]) +
-            " does not match gas-phase species mw " + std::to_string(mw[spf]));
+        const int fdspec = dep_indx[spf];
+        mw[spf] = mw_gas[fdspec] * SprayUnits::mass_conv;
+      }
+#ifdef PELE_SPRAY_GCM
+      {
+        amrex::ParmParse pp("particles");
+        std::vector<std::string> fuel_names;
+        pp.getarr("fuel_species", fuel_names);
+        amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> mw_fl;
+        getInpVal(mw_fl.data(), pp, fuel_names.data(), "molar_weight");
+        for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+          const amrex::Real diff = std::abs(mw_fl[spf] - mw[spf]);
+          if (diff > 1.E-3) {
+            amrex::Warning(
+              "Warning: GCM species " + fuel_names[spf] + " mw " +
+              std::to_string(mw_fl[spf]) +
+              " does not match gas-phase species mw " +
+              std::to_string(mw[spf]));
+          }
         }
       }
-    }
-#endif // PELE_SPRAY_GCM
-#else  // SPRAY_FUEL_NUM > NUM_SPECIES
-    // Must read in molecular weights when SPRAY_FUEL_NUM > NUM_SPECIES
+#endif     // PELE_SPRAY_GCM
+    } else // SPRAY_FUEL_NUM > N_pc: Many-to-one, must read in liquid molecular
+           // weights
     {
       amrex::Warning(
-        "Warning: Spray with SPRAY_FUEL_NUM > NUM_SPECIES still under "
-        "development and requires user specified molecular weights for liquid "
-        "species");
+        "Warning: Deposition of multiple liquid species to a single gas phase "
+        "species is still under development and requires user-specified "
+        "molecular weights for liquid species");
       amrex::ParmParse pp("particles");
       std::vector<std::string> fuel_names;
       pp.getarr("fuel_species", fuel_names);
       getInpVal(mw.data(), pp, fuel_names.data(), "molar_weight");
     }
-#endif
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Source/Spray/SpraySetup.cpp
+++ b/Source/Spray/SpraySetup.cpp
@@ -40,7 +40,7 @@ SprayParticleContainer::readSprayParams(int& particle_verbose)
   ParmParse pp("particles");
   // Control the verbosity of the Particle class
   pp.query("v", particle_verbose);
-
+  m_sprayData->verbose = particle_verbose;
   pp.query("mass_transfer", m_sprayData->mass_trans);
   pp.query("mom_transfer", m_sprayData->mom_trans);
   pp.query("fixed_parts", m_sprayData->fixed_parts);
@@ -266,20 +266,20 @@ SprayParticleContainer::spraySetup(
     amrex::Gpu::hostToDevice, tmp_pc_indx, tmp_pc_indx + m_sprayData->N_pc,
     m_sprayData->pc_indx);
 
-  amrex::Print() << "\nMapping for spray species: \n";
-  for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-    amrex::Print() << spf << ": " << m_sprayFuelNames[spf]
-                   << "\n     mapped to gas species "
-                   << m_sprayData->dep_indx[spf] << ": "
-                   << spec_names[m_sprayData->dep_indx[spf]]
-                   << "\n     dep_indx[" << spf
-                   << "] = " << m_sprayData->dep_indx[spf] << "\n";
-  }
-  amrex::Print() << "\nMapping for phase change species: \n";
-  for (int i = 0; i < m_sprayData->N_pc; ++i) {
-    int pcspec = m_sprayData->pc_indx[i];
-    amrex::Print() << "    pc_indx[" << i << "] = " << pcspec << ": "
-                   << spec_names[pcspec] << "\n";
+  if (m_sprayData->verbose) {
+    amrex::Print() << "\nMapping for spray species: \n";
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      amrex::Print() << spf << ": " << m_sprayFuelNames[spf]
+                     << "\n     mapped to gas species "
+                     << m_sprayData->dep_indx[spf] << ": "
+                     << spec_names[m_sprayData->dep_indx[spf]] << "\n";
+    }
+    amrex::Print() << "\nMapping for phase change species: \n";
+    for (int i = 0; i < m_sprayData->N_pc; ++i) {
+      int pcspec = m_sprayData->pc_indx[i];
+      amrex::Print() << "    pc_indx[" << i << "] = " << pcspec << ": "
+                     << spec_names[pcspec] << "\n";
+    }
   }
 
   auto eos = pele::physics::PhysicsType::eos(eosparms_h);

--- a/Source/Spray/SpraySetup.cpp
+++ b/Source/Spray/SpraySetup.cpp
@@ -278,7 +278,8 @@ SprayParticleContainer::spraySetup(
   amrex::GpuArray<amrex::Real, NUM_SPECIES> mw;
   Vector<Real> fuelEnth(NUM_SPECIES);
   eos.molecular_weight(mw.data());
-  m_sprayData->liqprops.init_mw(mw, m_sprayData->dep_indx.data());
+  m_sprayData->liqprops.init_mw(
+    mw, m_sprayData->dep_indx.data(), m_sprayData->N_pc);
   eos.T2Hi(m_sprayData->liqprops.ref_T, fuelEnth.data());
   for (int ns = 0; ns < SPRAY_FUEL_NUM; ++ns) {
     const int fdspec = m_sprayData->dep_indx[ns];
@@ -401,7 +402,8 @@ SprayParticleContainer::spraySetup(
   amrex::Vector<amrex::Real> mw(chemspec_names.size());
   auto eos = pele::physics::PhysicsType::eos(eosparms_h);
   eos.molecular_weight(mw.data());
-  m_sprayData->liqprops.init_mw(mw.data(), m_sprayData->dep_indx.data());
+  m_sprayData->liqprops.init_mw(
+    mw.data(), m_sprayData->dep_indx.data(), m_sprayData->N_pc);
 
 #endif
   // Stuff for both detailed chem and manifold

--- a/Source/Spray/SpraySetup.cpp
+++ b/Source/Spray/SpraySetup.cpp
@@ -195,7 +195,7 @@ SprayParticleContainer::readSprayParams(int& particle_verbose)
   }
 
   if (particle_verbose >= 1 && ParallelDescriptor::IOProcessor()) {
-    Print() << "Spray fuel species " << m_sprayFuelNames[0];
+    Print() << "Spray fuel species: " << m_sprayFuelNames[0];
 #if SPRAY_FUEL_NUM > 1
     for (int i = 1; i < SPRAY_FUEL_NUM; ++i) {
       Print() << ", " << m_sprayFuelNames[i];
@@ -232,14 +232,6 @@ SprayParticleContainer::spraySetup(
       Abort(
         "Spray species " + m_sprayFuelNames[spf] + " deposits to " +
         m_sprayDepNames[spf] + ", which is not found in gas species list");
-    }
-  }
-
-  for (int i = 0; i < SPRAY_FUEL_NUM; ++i) {
-    for (int j = i + 1; j < SPRAY_FUEL_NUM; ++j) {
-      if (m_sprayData->dep_indx[i] == m_sprayData->dep_indx[j]) {
-        m_sprayData->liquid_spec_share_gas_dep = true;
-      }
     }
   }
 
@@ -417,7 +409,6 @@ SprayParticleContainer::spraySetup(
   eos.molecular_weight(mw.data());
   m_sprayData->liqprops.init_mw(mw.data(), m_sprayData->dep_indx.data());
 
-  // TODO: Handle latent heat for Manifold EOS
 #endif
   // Stuff for both detailed chem and manifold
   for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {

--- a/Source/Spray/SpraySetup.cpp
+++ b/Source/Spray/SpraySetup.cpp
@@ -75,6 +75,12 @@ SprayParticleContainer::readSprayParams(int& particle_verbose)
     pp.getarr("fuel_species", fuel_names);
     if (pp.contains("dep_fuel_species")) {
       has_dep_spec = true;
+      const int ndfuel = pp.countval("dep_fuel_species");
+      if (ndfuel != SPRAY_FUEL_NUM) {
+        amrex::Abort(
+          "Number of dep_fuel_species in input file must match "
+          "SPRAY_FUEL_NUM");
+      }
       pp.getarr("dep_fuel_species", dep_fuel_names);
     }
 #ifdef USE_MANIFOLD_EOS
@@ -249,14 +255,8 @@ SprayParticleContainer::spraySetup(
   }
 
   // Set of phase change species
-  int tmp_pc_indx[NUM_SPECIES];
-  m_sprayData->N_pc =
-    m_sprayData->binary_csr_nonzerorows(m_sprayData->L_row, tmp_pc_indx);
-  m_sprayData->pc_indx =
-    (int*)amrex::The_Arena()->alloc(m_sprayData->N_pc * sizeof(int));
-  amrex::Gpu::copy(
-    amrex::Gpu::hostToDevice, tmp_pc_indx, tmp_pc_indx + m_sprayData->N_pc,
-    m_sprayData->pc_indx);
+  m_sprayData->N_pc = m_sprayData->binary_csr_nonzerorows(
+    m_sprayData->L_row, m_sprayData->pc_indx.data());
 
   if (m_sprayData->verbose) {
     amrex::Print() << "\nMapping for spray species: \n";
@@ -360,14 +360,8 @@ SprayParticleContainer::spraySetup(
   }
 
   // Set of phase change species
-  int tmp_pc_indx[SPRAY_FUEL_NUM];
-  m_sprayData->N_pc =
-    m_sprayData->binary_csr_nonzerorows(m_sprayData->L_row, tmp_pc_indx);
-  m_sprayData->pc_indx =
-    (int*)amrex::The_Arena()->alloc(m_sprayData->N_pc * sizeof(int));
-  amrex::Gpu::copy(
-    amrex::Gpu::hostToDevice, tmp_pc_indx, tmp_pc_indx + m_sprayData->N_pc,
-    m_sprayData->pc_indx);
+  m_sprayData->N_pc = m_sprayData->binary_csr_nonzerorows(
+    m_sprayData->L_row, m_sprayData->pc_indx.data());
 
   // Check that m_sprayData->N_pc = NUM_SPECIES - 1 (only true for manifold EOS)
   if (m_sprayData->N_pc != NUM_SPECIES - 1) {


### PR DESCRIPTION
Updates for PR review (in progress):

- Add verbosity checks
- eliminate unused `liquid_spec_share_gas_dep` variable
- make pc_index a fixed length array to avoid potential data copying issues
- in `init_mw` instead of using SPRAY_FUEL_NUM > NUM_SPECIES to determine if we're in a many-to-one case, compare SPRAY_FUEL_NUM to N_pc.