### PR TITLE
Many to one fixes

### DIFF
--- a/Source/Eos/EOS.H
+++ b/Source/Eos/EOS.H
@@ -168,9 +168,7 @@ speciesNames<Manifold>(
   }
   spn[MANIFOLD_DIM] = "XRHO";
 }
-#endif
 
-#ifndef AMREX_USE_SYCL
 template <>
 inline void
 varNames<Manifold>(
@@ -190,9 +188,7 @@ varNames<Manifold>(
     allvarnames[n] = amrex::trim(nametmp);
   }
 }
-#endif
 
-#ifndef AMREX_USE_SYCL
 template <>
 inline void
 chemSpeciesNames<Manifold>(
@@ -204,12 +200,11 @@ chemSpeciesNames<Manifold>(
       "species names");
   }
   const auto* mani_data = eparm->manf_data;
-  for (int n = 0; n < mani_data->Nvar; n++) {
+  for (int n = 0; n < eparm->num_chemspecies; n++) {
+    int idx = eparm->idx_chemspecies[n];
     std::string nametmp = std::string(
-      &(mani_data->varnames)[n * mani_data->len_str], mani_data->len_str);
-    if (nametmp.substr(0, 2) == "Y-") {
-      chemspn.push_back(amrex::trim(nametmp.substr(2U, std::string::npos)));
-    }
+      &(mani_data->varnames)[idx * mani_data->len_str], mani_data->len_str);
+    chemspn.push_back(amrex::trim(nametmp.substr(2U, std::string::npos)));
   }
 }
 #endif

--- a/Source/Eos/EosParams.H
+++ b/Source/Eos/EosParams.H
@@ -125,6 +125,15 @@ struct InitParm<eos::EosParm<eos::Manifold>>
     bool required = false;
 #ifdef PELE_USE_SPRAY
     required = true;
+    amrex::Vector<std::string> spray_species;
+    {
+      amrex::ParmParse ppp("particles");
+      if (ppp.contains("dep_fuel_species")) {
+        ppp.getarr("dep_fuel_species", spray_species);
+      } else {
+        ppp.getarr("fuel_species", spray_species);
+      }
+    }
 #endif
     parm_in->m_h_parm.idx_Cp = get_var_index("CP", h_manf_data_in, required);
     parm_in->m_h_parm.idx_Cp_fuel =
@@ -140,7 +149,19 @@ struct InitParm<eos::EosParm<eos::Manifold>>
         std::string nametmp = std::string(
           &(mani_data->varnames)[n * mani_data->len_str], mani_data->len_str);
         if (nametmp.substr(0, 2) == "Y-") {
+          // A bit of a hack - if doing spray we only take the species involved
+          // in spray phase change
+#ifdef PELE_USE_SPRAY
+          std::string find_spec =
+            amrex::trim(nametmp.substr(2U, std::string::npos));
+          if (
+            std::find(spray_species.begin(), spray_species.end(), find_spec) !=
+            spray_species.end()) {
+            spec_idx_vect.emplace_back(n);
+          }
+#else
           spec_idx_vect.emplace_back(n);
+#endif
         }
       }
       const int num_of_chemspecies = static_cast<int>(spec_idx_vect.size());

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -269,9 +269,8 @@ struct calcVaporState<pele::physics::eos::Manifold>
     amrex::Real theta = (1.0 - sumYripc) / (1.0 - sumYgipc);
 
     // Now calculate \zi_{r,j}
-    amrex::GpuArray<amrex::Real, NUM_SPECIES> zi_rj{0.0};
-    amrex::GpuArray<amrex::Real, NUM_SPECIES> WYgi{0.0}; // W_ij Y_{g,i}^{pc}
-    amrex::GpuArray<amrex::Real, NUM_SPECIES> WYri{0.0}; // W_ij Y_{r,i}^{pc}
+    amrex::GpuArray<amrex::Real, NUM_SPECIES - 1> WYgi{0.0}; // W_ij Y_{g,i}^{pc}
+    amrex::GpuArray<amrex::Real, NUM_SPECIES - 1> WYri{0.0}; // W_ij Y_{r,i}^{pc}
 
     // Alternative way of doing above without using W_ij assuming W_ij is some
     // row exchanged form of the identity matrix
@@ -284,9 +283,9 @@ struct calcVaporState<pele::physics::eos::Manifold>
       }
     }
 
-    for (int n = 0; n < NUM_SPECIES; n++) {
-      zi_rj[n] = WYri[n] + theta * (gpv.Y_fluid[n] - WYgi[n]);
-      Y_skin[n] = zi_rj[n];
+    for (int n = 0; n < NUM_SPECIES - 1; n++) {
+      const amrex::Real zi_rj = WYri[n] + theta * (gpv.Y_fluid[n] - WYgi[n]);
+      Y_skin[n] = zi_rj;
     }
 
     eos.Y2WBAR(Y_skin, mw_skin);
@@ -391,6 +390,7 @@ calculateSpraySource(
         fdat, gpv, rule, T_part, C_eps, mw_part, Y_part.data(), T_skin, cBoilT,
         Y_skin.data(), X_vn.data(), L_n.data(), B_M, sumXVap, cp_skin, mw_skin);
     } else {
+      // Does this need modified for manifold??
       for (int n = 0; n < NUM_SPECIES; ++n) {
         Y_skin[n] = gpv.Y_fluid[n];
       }

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -201,7 +201,6 @@ struct calcVaporState<pele::physics::eos::Manifold>
 
     // Estimate X_{v,n} from the liquid state
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      const int fmspec = fdat.dep_manifold_indx[spf];
       const int fdspec = fdat.dep_indx[spf];
 
       // Compute latent heat using correlation
@@ -215,7 +214,7 @@ struct calcVaporState<pele::physics::eos::Manifold>
 
       // Mole fraction in gas phase
       const amrex::Real X_gi =
-        gpv.Yspec_fluid[fdspec] * gpv.mw_mix / gpv.mw[fmspec];
+        gpv.Yspec_fluid[fdspec] * gpv.mw_mix / gpv.mw[fdspec];
 
       // Estimate X_gn by distributing X_gi across all the liquid species
       const amrex::Real sumXdn_SLi =

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -391,7 +391,6 @@ calculateSpraySource(
         fdat, gpv, rule, T_part, C_eps, mw_part, Y_part.data(), T_skin, cBoilT,
         Y_skin.data(), X_vn.data(), L_n.data(), B_M, sumXVap, cp_skin, mw_skin);
     } else {
-      // Does this need modified for manifold??
       for (int n = 0; n < NUM_SPECIES; ++n) {
         Y_skin[n] = gpv.Y_fluid[n];
       }

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -6,6 +6,25 @@
 #include "SprayPropertiesGCM.H"
 #include <AMReX_RealVect.H>
 
+// Things get tricky for Spray + Manifold because for Manifold EOS, the
+// "species" are actually the manifold parameters, but we need the actual
+// species for vapor/liquid calculations in the spray module. For manifold, this
+// is set up so we only need to lookup gas phase species that correspond to
+// lqiuid phase species, rather than all possible gas phase species. We also set
+// up macros to define 0 length arrays if variables are unneeded when not using
+// Manifold EOS.
+#ifdef USE_MANIFOLD_EOS
+#define NUM_CHEM_SPECIES SPRAY_FUEL_NUM
+#define NUM_CHEM_SPECIES_MANI_ONLY NUM_CHEM_SPECIES
+#define NUM_SPECIES_MANI_ONLY NUM_SPECIES
+#define SPRAY_FUEL_NUM_MANI_ONLY SPRAY_FUEL_NUM
+#else
+#define NUM_CHEM_SPECIES NUM_SPECIES
+#define NUM_CHEM_SPECIES_MANI_ONLY 0
+#define NUM_SPECIES_MANI_ONLY 0
+#define SPRAY_FUEL_NUM_MANI_ONLY 0
+#endif
+
 // Spray flags and indices
 struct SprayComps
 {
@@ -48,19 +67,15 @@ struct GasPhaseVals
   amrex::Real T_fluid;
   amrex::Real rho_fluid;
   amrex::Real p_fluid;
-  amrex::GpuArray<amrex::Real, NUM_SPECIES> Y_fluid;
+  amrex::GpuArray<amrex::Real, NUM_SPECIES> Y_fluid{0.0};
   // for manifold Y_fluid is manifold parameters, Yspec_fluid is chemical
   // species - Yspec_fluid is unused for detailed chem
-#ifdef USE_MANIFOLD_EOS
-  amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Yspec_fluid;
-#else
-  amrex::GpuArray<amrex::Real, 0> Yspec_fluid;
-#endif
+  amrex::GpuArray<amrex::Real, NUM_CHEM_SPECIES_MANI_ONLY> Yspec_fluid{0.0};
   amrex::Real mw_mix;
-  amrex::GpuArray<amrex::Real, NUM_SPECIES> mw;
+  amrex::GpuArray<amrex::Real, NUM_CHEM_SPECIES> mw{0.0};
   amrex::RealVect fluid_mom_src;
   amrex::Real fluid_mass_src;
-  amrex::GpuArray<amrex::Real, NUM_SPECIES> fluid_Y_dot;
+  amrex::GpuArray<amrex::Real, NUM_SPECIES> fluid_Y_dot{0.0};
   amrex::Real fluid_eng_src;
 
   AMREX_GPU_DEVICE AMREX_FORCE_INLINE void reset()
@@ -98,19 +113,15 @@ struct SprayData
   amrex::RealVect body_force = amrex::RealVect::TheZeroVector();
   amrex::GpuArray<int, SPRAY_FUEL_NUM> dep_indx{};
   amrex::GpuArray<int, SPRAY_FUEL_NUM> L_col{};
-#ifndef USE_MANIFOLD_EOS
-  amrex::GpuArray<int, NUM_SPECIES + 1> L_row{};
-  amrex::GpuArray<int, 0> dep_manifold_indx{};
-  amrex::GpuArray<int, 0> pc_manifold_indx{};
-#else
-  amrex::GpuArray<int, SPRAY_FUEL_NUM + 1> L_row{};
-  amrex::GpuArray<int, SPRAY_FUEL_NUM> dep_manifold_indx{};
-  amrex::GpuArray<int, NUM_SPECIES - 1> pc_manifold_indx{};
-#endif
+  amrex::GpuArray<int, NUM_CHEM_SPECIES + 1> L_row{};
   int N_pc = 0;
   // We will only use the first N_pc entries, but don't know that number a
   // priori so allocate NUM_SPECIES which is always >= N_pc
-  amrex::GpuArray<int, NUM_SPECIES> pc_indx;
+  amrex::GpuArray<int, NUM_CHEM_SPECIES> pc_indx;
+
+  // Arrays only used for Manifold EOS
+  amrex::GpuArray<int, SPRAY_FUEL_NUM_MANI_ONLY> dep_manifold_indx{};
+  amrex::GpuArray<int, NUM_CHEM_SPECIES_MANI_ONLY> pc_manifold_indx{};
 
   // Instance of the liquid properties for the specified model
   pele::physics::SprayProps::LiqPropType liqprops;

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -51,7 +51,11 @@ struct GasPhaseVals
   amrex::GpuArray<amrex::Real, NUM_SPECIES> Y_fluid;
   // for manifold Y_fluid is manifold parameters, Yspec_fluid is chemical
   // species - Yspec_fluid is unused for detailed chem
+#ifdef USE_MANIFOLD_EOS
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Yspec_fluid;
+#else
+  amrex::GpuArray<amrex::Real, 0> Yspec_fluid;
+#endif
   amrex::Real mw_mix;
   amrex::GpuArray<amrex::Real, NUM_SPECIES> mw;
   amrex::RealVect fluid_mom_src;

--- a/Source/Spray/SprayInterpolation.H
+++ b/Source/Spray/SprayInterpolation.H
@@ -154,10 +154,9 @@ InterpolateGasPhase(
   }
 
   // In the case of  manifold model simulations, the objective is to get the
-  // mass fractions of all the liquid fuel species, at the spray location, read
+  // mass fractions of all the phase-change gas species, at the spray location, read
   // from the manifold table. We already have the interpolated value of manifold
-  // variables at the spray particle location stored in 'mass_frac'. I just need
-  // to call GenericReadManifoldData
+  // variables at the spray particle location stored in 'mass_frac'.
 #ifdef USE_MANIFOLD_EOS
   for (int n = 0; n < SPRAY_FUEL_NUM; n++) {
     amrex::Real tempval;

--- a/Source/Spray/SprayParticles.cpp
+++ b/Source/Spray/SprayParticles.cpp
@@ -335,7 +335,7 @@ SprayParticleContainer::updateParticles(
           GpuArray<Real, SPRAY_FUEL_NUM>
             cBoilT; // Boiling temperature at current pressure
           eos.molecular_weight(gpv.mw.data());
-          for (int n = 0; n < NUM_SPECIES; ++n) {
+          for (int n = 0; n < NUM_CHEM_SPECIES; ++n) {
             gpv.mw[n] *= SprayUnits::mass_conv;
           }
           GpuArray<IntVect, AMREX_D_PICK(2, 4, 8)>

--- a/Source/Spray/SpraySetup.cpp
+++ b/Source/Spray/SpraySetup.cpp
@@ -295,6 +295,12 @@ SprayParticleContainer::spraySetup(
       "SpraySetup: Manifold EOS must contains spec molecular weights for "
       "Spray");
   }
+  // Verify EOS will not give too many species for us to store
+  if (eosparms_h->num_chemspecies > NUM_CHEM_SPECIES) {
+    amrex::Error(
+      "SpraySetup: Manifold EOS table must not contain more than "
+      "NUM_CHEM_SPECIES = SPRAY_FUEL_NUM chemical species");
+  }
 
   Vector<std::string> chemspec_names, manivar_names;
   pele::physics::eos::chemSpeciesNames<pele::physics::PhysicsType::eos_type>(


### PR DESCRIPTION
This graphic summarizes the issue we currently have with many-to-one + Manifold (don't know num_chemspecies from the manifold a priori to allocate the right amount of memory on GPU):

<img width="1808" height="1010" alt="Screenshot 2026-02-13 at 4 22 26 PM" src="https://github.com/user-attachments/assets/62ac962f-fca1-40dc-9ddb-a67c9b2aca9b" />

The implemented fix is a little bit different than outlined in the figure. A modification is made so that, when spray is active, the routines to get chemspecies from the manifold model only return the chemspecies involved in spray phase change. This ensures that num_chemspecies <= SPRAY_FUEL_NUM, so we can always be sure to allocate enough space for the data.